### PR TITLE
keybinding: Action Button Recenter

### DIFF
--- a/packages/keymaps/src/browser/style/index.css
+++ b/packages/keymaps/src/browser/style/index.css
@@ -37,7 +37,6 @@
 
 .kb-action-item {
   visibility: hidden;
-  padding-right: 5px;
 }
 
 .kb table {
@@ -172,7 +171,4 @@
 
 .kb-actions-icons {
   display: block;
-  width: 50%;
-  margin-left: auto;
-  margin-right: auto;
 }


### PR DESCRIPTION
After Editing keybindding the reset button is half hidden.
This commit should properly center the keybidding action buttons.

#### What it does
BEFORE
![image](https://user-images.githubusercontent.com/48699277/226740758-4fef40a7-b1bc-4112-84e4-db2fd03cacac.png)
![image](https://user-images.githubusercontent.com/48699277/226740856-60271b12-3aca-44c8-9875-8df80cb1686b.png)

AFTER
![image](https://user-images.githubusercontent.com/48699277/226741383-de417d77-70b6-4dba-aecd-b7b535a1afb7.png)
![image](https://user-images.githubusercontent.com/48699277/226741474-1361cfae-826c-4be9-8c26-375afcd3aa8e.png)


<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
