### PR TITLE
themes: High Contrast Dark missing markers

### DIFF
--- a/packages/core/src/browser/common-styling-participants.ts
+++ b/packages/core/src/browser/common-styling-participants.ts
@@ -182,12 +182,19 @@ export class TabbarStylingParticipant implements StylingParticipant {
 
         if (highContrast && focusBorder) {
             collector.addRule(`
+                #theia-bottom-content-panel .p-TabBar .p-TabBar-tab,
                 #theia-main-content-panel .p-TabBar .p-TabBar-tab {
                     outline-offset: -4px;
                 }
+                #theia-bottom-content-panel .p-TabBar .p-TabBar-tab.p-mod-current,
                 #theia-main-content-panel .p-TabBar .p-TabBar-tab.p-mod-current {
                     outline: 1px solid ${focusBorder};
                 }
+                #theia-bottom-content-panel .p-TabBar:not(.theia-tabBar-active) .p-TabBar-tab.p-mod-current,
+                #theia-main-content-panel .p-TabBar:not(.theia-tabBar-active) .p-TabBar-tab.p-mod-current {
+                    outline: 1px dotted ${focusBorder};
+                }
+                #theia-bottom-content-panel .p-TabBar .p-TabBar-tab:not(.p-mod-current):hover,
                 #theia-main-content-panel .p-TabBar .p-TabBar-tab:not(.p-mod-current):hover {
                     outline: 1px dashed ${focusBorder};
                 }
@@ -237,6 +244,19 @@ export class TabbarStylingParticipant implements StylingParticipant {
             `);
         }
 
+        // Activity Bar Active Border
+        const activityBarActiveBorder = theme.getColor('activityBar.activeBorder') || 'var(--theia-activityBar-foreground)';
+        collector.addRule(`
+            .p-TabBar.theia-app-left .p-TabBar-tab.p-mod-current {
+                border-top-color: transparent;
+                box-shadow: 2px 0 0 ${activityBarActiveBorder} inset;
+            }
+          
+            .p-TabBar.theia-app-right .p-TabBar-tab.p-mod-current {
+                border-top-color: transparent;
+                box-shadow: -2px 0 0 ${activityBarActiveBorder} inset;
+            }
+        `);
         // Hover Background
         const tabHoverBackground = theme.getColor('tab.hoverBackground');
         if (tabHoverBackground) {


### PR DESCRIPTION
#### What it does
Implements the following features in the High Contrast Dark theme:
- The missing active border marker in the sidepanel
- The dotted selected tab marker in inactive tab groups
- The missing selected tab marker in the bottom-content-panel.

#### How to test
1. Run Theia
2. Change theme to `High Contrast Dark`
3. Check if the selected sidepanel tab has the active border marker.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
