### PR TITLE
Search-In-Workspace: Include/Exclude Inputbox placeholder

### DIFF
--- a/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
+++ b/packages/search-in-workspace/src/browser/search-in-workspace-widget.tsx
@@ -619,6 +619,10 @@ export class SearchInWorkspaceWidget extends BaseWidget implements StatefulWidge
                 defaultValue={value}
                 autoComplete='off'
                 id={kind + '-glob-field'}
+                placeholder={kind === 'include'
+                    ? nls.localizeByDefault('e.g. *.ts, src/**/include')
+                    : nls.localizeByDefault('e.g. *.ts, src/**/exclude')
+                }
                 onKeyUp={e => {
                     if (e.target) {
                         const targetValue = (e.target as HTMLInputElement).value || '';

--- a/packages/search-in-workspace/src/browser/styles/index.css
+++ b/packages/search-in-workspace/src/browser/styles/index.css
@@ -189,6 +189,10 @@
     font-size: var(--theia-ui-font-size0);
 }
 
+.t-siw-search-container .searchHeader .glob-field-container .glob-field .theia-input:not(:focus)::placeholder {
+    color: transparent;
+}
+
 .t-siw-search-container .resultContainer {
     height: 100%;
     margin-left: 13px;


### PR DESCRIPTION

#### What it does
This commit implements the include and exclude inputbox placeholder.

#### How to test
1. Run Theia
2. Go to the search tab
3. Focus on an include or exclude inputbox
4. Check the placeholder text appears

![SIW-IncludeExclude-placeholder](https://user-images.githubusercontent.com/48699277/230923019-37419c39-7c53-40bf-b03f-b7f5959440b9.gif)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
