### PR TITLE
quick-open: `Esc` closes inputbox when focus out.

### DIFF
--- a/packages/monaco/src/browser/monaco-quick-input-service.ts
+++ b/packages/monaco/src/browser/monaco-quick-input-service.ts
@@ -96,6 +96,7 @@ export class MonacoQuickInputImplementation implements IQuickInputService {
         // Hook into the theming service of Monaco to ensure that the updates are ready.
         StandaloneServices.get(IStandaloneThemeService).onDidColorThemeChange(() => this.controller.applyStyles(this.getStyles()));
         window.addEventListener('resize', () => this.updateLayout());
+        window.addEventListener('keydown', event => { if (event.code === 'Escape') { this.controller.hide(); } });
     }
 
     setContextKey(key: string | undefined): void {


### PR DESCRIPTION
#### What it does
Closes: 6773

It has some difficulty when other elements are open that also close with `esc` when out of focus.
For example, if a notification is showing the notification will close on the `esc` key-press. Leaving the Quick Box still open requiring a second `esc` key-press. This is the same in VS Code.

#### How to test
1. Run Theia
2. Open a QuickInput that remains open when it is out of Focus
3. Focus on something else (i.e. Editor, Tabs, etc)
4. Press `esc` key
5. Verify the QuickInput closes.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
